### PR TITLE
l2 regularization of weights only

### DIFF
--- a/DAE.py
+++ b/DAE.py
@@ -83,7 +83,8 @@ class DAE:
         MSE_loss=self._compute_loss(outputs,x,num_train_labels)
         
         if self.FLAGS.l2_reg==True:
-            l2_loss = tf.add_n([tf.nn.l2_loss(v) for v in tf.trainable_variables()])
+            l2_loss = tf.add_n([tf.nn.l2_loss(v) for v in tf.trainable_variables()
+                                if 'bias' not in v.name])
             MSE_loss = MSE_loss +  self.FLAGS.lambda_ * l2_loss
         
         train_op=tf.train.AdamOptimizer(self.FLAGS.learning_rate).minimize(MSE_loss)


### PR DESCRIPTION
Modified `l2_loss` term so that it does not count biases, only weights. Typically we do not want to regularize biases as they are:

1. additive, not multiplicative, and so are far less likely to cause numeric issues if they get too large, and
2. not necessarily limited by real-world constraints to be near zero.

Basically our data can have biases that are far from zero, so we shouldn't try to keep them close to zero.